### PR TITLE
Performance improved through numpy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ as well as an improved FW for Hantek 6022 USB Oscilloscopes''',
     version=__version__,
     license='GPLv2',
     # the required python packages
-    install_requires=['libusb1', 'matplotlib'],
+    install_requires=['libusb1', 'matplotlib', 'numpy'],
     url='https://github.com/Ho-Ro/Hantek6022API',
     packages=[ 'PyHT6022', 'PyHT6022.Firmware' ],
     package_data={


### PR DESCRIPTION
Numpy is now used in functions `scale_read_data` and `convert_sampling_rate_to_measurement_times` to improve performance.

Since these functions are time critical, the execution speed should be as fast as possible. With numpy, the performance can almost be doubled here.

Output of performance.txt:
`measurement times new: 2.313504457473755`
`measurement times old: 5.265141010284424`
`scale read data new: 5.61890435218811`
`scale read data old: 8.594855070114136`


[performance.txt](https://github.com/Ho-Ro/Hantek6022API/files/12674296/performance.txt)
