### PR TITLE
fix for macOS as macOS doesn't support kernel driver detaching

### DIFF
--- a/PyHT6022/LibUsbScope.py
+++ b/PyHT6022/LibUsbScope.py
@@ -223,7 +223,7 @@ class Oscilloscope(object):
         if not self.device and not self.setup():
             return False
         self.device_handle = self.device.open()
-        if os.name == 'posix' and self.device_handle.kernelDriverActive(0):
+        if os.name == 'posix' and not os.uname().sysname == 'Darwin' and self.device_handle.kernelDriverActive(0):
             self.device_handle.detachKernelDriver(0)
         try:
             self.device_handle.claimInterface(0)


### PR DESCRIPTION
A small fix for macOS users as mentioned here https://github.com/libusb/libusb/issues/908#issuecomment-820018553 macOS doesn't support kernel driver detaching or `kernelDriverActive()` method.

Calling these methods results in a `usb1.USBErrorNotFound: LIBUSB_ERROR_NOT_FOUND [-5]` error.